### PR TITLE
Fixed NPE when scanning for expired observations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>edu.whimc</groupId>
 	<artifactId>WHIMC-ObservationDisplayer</artifactId>
-	<version>1.4.4</version>
+	<version>1.4.5</version>
 	<name>WHIMC ObservationDisplayer</name>
 	<description>Create holographic observations in worlds</description>
 

--- a/src/main/java/edu/whimc/observationdisplayer/Observation.java
+++ b/src/main/java/edu/whimc/observationdisplayer/Observation.java
@@ -60,6 +60,7 @@ public class Observation {
     public static void scanForExpiredObservations(ObservationDisplayer plugin) {
         Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, () -> {
             long count = observations.stream()
+                    .filter(v -> v.getExpiration() != null)
                     .filter(v -> Instant.now().isAfter(v.getExpiration().toInstant()))
                     .filter(v -> !v.isTemporary())
                     .collect(Collectors.toList())


### PR DESCRIPTION
An NPE was being thrown when comparing the expiration for observations with no expiration.